### PR TITLE
Sorting: Add bag slot to list of sort keys

### DIFF
--- a/Sorting/Order.lua
+++ b/Sorting/Order.lua
@@ -29,6 +29,7 @@ local allSortKeys = {
     "invertedItemID",
     "invertedItemCount",
     "itemLink",
+    "slotID",
   },
   ["quality-legacy"] = { -- no longer used
     "priority",
@@ -52,6 +53,7 @@ local allSortKeys = {
     "invertedItemID",
     "invertedItemCount",
     "itemLink",
+    "slotID",
   },
   ["type-legacy"] = { -- no longer used
     "priority",
@@ -74,6 +76,7 @@ local allSortKeys = {
     "invertedItemID",
     "invertedItemCount",
     "itemLink",
+    "slotID",
   },
 }
 


### PR DESCRIPTION
This change adds the bag `slotID` to the list of sort keys to ensure deterministic sort order when sorting multiple stacks of identical items.