### PR TITLE
Equipment Manager Validity In Classic Era

### DIFF
--- a/API/EquipmentSets.lua
+++ b/API/EquipmentSets.lua
@@ -2,9 +2,10 @@ local _, addonTable = ...
 -- Blizzard Equipment sets (Wrath onwards)
 do
   local BlizzardSetTracker = CreateFrame("Frame")
+  local EquipmentManager_UnpackLocation = EquipmentManager_UnpackLocation
 
   function BlizzardSetTracker:OnLoad()
-    if addonTable.Constants.IsRetail and IsMacClient() then
+    if (not EquipmentManager_UnpackLocation) or (addonTable.Constants.IsRetail and IsMacClient()) then
       return
     end
 


### PR DESCRIPTION
Check if `EquipmentManager_UnpackLocation` is available in the current game version.

Though EquipmentManager isn't officially accessible in pre-Wrath WoW, addons like [Narcissus](https://legacy.curseforge.com/wow/addons/narcissus-classic) can use `C_EquipmentSet` APIs to create and equip sets, but it will cause errors in Baganator as it will try to access the nonexistent `EquipmentManager_UnpackLocation` to find the items.