### PR TITLE
Fix skin loading condition

### DIFF
--- a/Skins/ElvUI.lua
+++ b/Skins/ElvUI.lua
@@ -179,7 +179,7 @@ local function LoadSkin()
   end
 end
 
-if (select(4, C_AddOns.GetAddOnInfo("ElvUI"))) then
+if (C_AddOns.IsAddOnLoaded("ElvUI")) then
   addonTable.Skins.RegisterSkin(BAGANATOR_L_ELVUI, "elvui", LoadSkin, SkinFrame, SetConstants, {
     {
       type = "checkbox",

--- a/Skins/GW2.lua
+++ b/Skins/GW2.lua
@@ -389,6 +389,6 @@ local function LoadSkin()
   HideBagButtons()
 end
 
-if (select(4, C_AddOns.GetAddOnInfo("GW2_UI"))) then
+if (C_AddOns.IsAddOnLoaded("GW2_UI")) then
   addonTable.Skins.RegisterSkin(BAGANATOR_L_GW2_UI, "gw2_ui", LoadSkin, SkinFrame, SetConstants, {}, true)
 end

--- a/Skins/NDui.lua
+++ b/Skins/NDui.lua
@@ -141,6 +141,6 @@ local function LoadSkin()
   B, C, L, DB = unpack(NDui)
 end
 
-if (select(4, C_AddOns.GetAddOnInfo("NDui"))) then
+if (C_AddOns.IsAddOnLoaded("NDui")) then
   addonTable.Skins.RegisterSkin(BAGANATOR_L_NDUI, "ndui", LoadSkin, SkinFrame, SetConstants, {}, true)
 end


### PR DESCRIPTION
GetAddOnInfo 4th return is not actually "loaded" its "loadable". Meaning if user has ElvUI installed but disabled this will cause loading of skin and cause errors. This pull requests fixes this issue by using IsAddOnLoaded