### PR TITLE
Equipment Set: Handle skipped slots for MacOS

### DIFF
--- a/API/EquipmentSets.lua
+++ b/API/EquipmentSets.lua
@@ -52,7 +52,8 @@ if not addonTable.Constants.IsEra then
       local validItems = true
       if IsMacClient() then
         for _, itemID in pairs(C_EquipmentSet.GetItemIDs(setID)) do
-          if not C_Item.GetItemInfoInstant(itemID) then
+          -- itemID == -1 represents a "skipped" slot
+          if not C_Item.GetItemInfoInstant(itemID) and itemID ~= -1 then
             validItems = false
           end
         end


### PR DESCRIPTION
# Issues
- #415 

# Changes
- Handles skipped slots in equipment sets (id = -1)

# Rationale
- Equipment sets use `-1` to represent a "skipped" slot. The macOS check does a simple check to see if an item is valid, but that `-1` is never valid. We just need to handle that edge case in our valid item check.

# Screenshots
**Sets**
![sets](https://github.com/user-attachments/assets/d2e69c5c-eb36-48c5-a71f-6bb2f4f6d011)

**Before**
![before](https://github.com/user-attachments/assets/a492a2b5-e155-4d1c-9c1b-a0efd8a28cf2)

**After**
![image](https://github.com/user-attachments/assets/0fc67d15-547f-489b-b175-daa01cd988c7)
