### PR TITLE
Update Utilities.lua

### DIFF
--- a/ItemViewCommon/Utilities.lua
+++ b/ItemViewCommon/Utilities.lua
@@ -438,11 +438,11 @@ do
       "^" .. ITEM_SPELL_CHARGES_NONE .. "$",
     }
 
-    local escapeSequence = ITEM_SPELL_CHARGES:match("|4([^;]*);")
+    local escapeSequence = ITEM_SPELL_CHARGES:match("\1244([^;]*);")
 
     if escapeSequence then
       for _, part in ipairs({ strsplit(":", escapeSequence) }) do
-        table.insert(possibleChargePatterns, "^" .. (ITEM_SPELL_CHARGES:gsub("%%d", "%%d%+"):gsub("|4[^;]*;", part)) .. "$")
+        table.insert(possibleChargePatterns, "^" .. (ITEM_SPELL_CHARGES:gsub("%%d", "%%d%+"):gsub("\1244[^;]*;", part)) .. "$")
       end
     else
       table.insert(possibleChargePatterns, "^" .. ITEM_SPELL_CHARGES .. "$")


### PR DESCRIPTION
Fix match for |4 by using \1244

Currently items with no charges are separated from items with charges, but items with different number of charges are stacked together. e.g. 1 charge is merged together with 3 charges.
This fix will split them up again.