### PR TITLE
Make ConsolePort Cursor ignore dividers

### DIFF
--- a/ItemViewCommon/Layouts.xml
+++ b/ItemViewCommon/Layouts.xml
@@ -104,6 +104,9 @@
     <Scripts>
       <OnLoad method="OnLoad"/>
     </Scripts>
+    <Attributes>
+      <Attribute name="nodeignore" type="boolean" value="true"/>
+    </Attributes>
     <Layers>
       <Layer level="BACKGROUND">
         <Texture parentKey="Divider">


### PR DESCRIPTION
This is a minimal fix to make ConsolePort's interface cursor ignore category dividers. Since they are created as buttons, the cursor is fooled into thinking they are interactive, and they act like magnets for the cursor algorithm because they span the width of the frame.

Before:


https://github.com/user-attachments/assets/11d12822-feed-4393-be09-fe5a428fa917


After:


https://github.com/user-attachments/assets/390e1f89-1ac4-4acb-b8ab-c8252f29611b

